### PR TITLE
fix: clear diagnostics when new file is opened

### DIFF
--- a/packages/openscd/src/addons/History.ts
+++ b/packages/openscd/src/addons/History.ts
@@ -175,6 +175,7 @@ export class OscdHistory extends LitElement {
 
   private onReset() {
     this.log = [];
+    this.diagnoses.clear();
     this.editor.reset();
     this.updateHistory();
   }
@@ -287,7 +288,6 @@ export class OscdHistory extends LitElement {
     this.host.addEventListener('issue', this.onIssue);
     this.host.addEventListener('history-dialog-ui', this.historyUIHandler);
     this.host.addEventListener('empty-issues', this.emptyIssuesHandler);
-    this.diagnoses.clear();
   }
 
   disconnectedCallback(): void {

--- a/packages/openscd/test/unit/Historing.test.ts
+++ b/packages/openscd/test/unit/Historing.test.ts
@@ -207,5 +207,24 @@ describe('HistoringElement', () => {
         expect(issue.title).to.equal('test run 3');
       });
     });
+
+    it('clears diagnoses when a new SCD file is opened (reset)', async () => {
+      element.dispatchEvent(
+        newIssueEvent({
+          validatorId: '/src/validators/ValidateSchema.js',
+          title: 'test run 1',
+        })
+      );
+      element.dispatchEvent(
+        newIssueEvent({
+          validatorId: '/src/validators/ValidateTemplates.js',
+          title: 'test run 3',
+        })
+      );
+      expect(element.diagnoses.size).to.equal(2);
+      element.dispatchEvent(newLogEvent({ kind: 'reset' }));
+      await element.updateComplete;
+      expect(element.diagnoses.size).to.equal(0);
+    });
   });
 });


### PR DESCRIPTION
closes #18 