### PR TITLE
fix: change release please config

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -21,61 +21,61 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd #v6.0.2
         with:
           submodules: "true"
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f #v6.3.0
         with:
           node-version: "20.x"
           registry-url: "https://registry.npmjs.org"
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - run: npm ci --include=optional
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
       - run: npm run build
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
 
       - name: Publish core to npm
         run: cd packages/core && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['packages/core--release_created'] }}
         continue-on-error: true
 
       - name: Publish forms to npm
         run: cd packages/forms && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['packages/forms--release_created'] }}
         continue-on-error: true
 
       - name: Publish xml to npm
         run: cd packages/xml && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['packages/xml--release_created'] }}
         continue-on-error: true
 
       - name: Publish plugins to npm
         run: cd packages/plugins && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['packages/plugins--release_created'] }}
         continue-on-error: true
 
       - name: Publish open-scd to npm
         run: cd packages/openscd && npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs['packages/openscd--release_created'] }}
         continue-on-error: true
 
 
       - name: Create and Zip Build Assets
-        if: ${{ steps.release.outputs.release_created }}
-        run: |
+        if: ${{ steps.release.outputs.releases_created }}
+        run: | 
           zip -r open-scd.zip ./packages/distribution/build/
           tar -czvf open-scd.tar.gz ./packages/distribution/build/
 
       - name: Upload Build Assets
-        if: ${{ steps.release.outputs.release_created }}
+        if: ${{ steps.release.outputs.releases_created }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run:  gh release upload ${{ steps.release.outputs.tag_name }} open-scd.zip open-scd.tar.gz

--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,8 @@
 {
-  "packages/openscd": "0.37.0",
-  "packages/core": "0.1.4",
+  "packages/openscd": "0.34.49",
+  "packages/core": "0.1.23",
+  "packages/forms": "0.0.1",
+  "packages/xml": "0.0.1",
+  "packages/plugins": "0.0.6",
   ".": "0.45.13"
 }

--- a/packages/openscd/README.md
+++ b/packages/openscd/README.md
@@ -7,6 +7,8 @@
 
 Open Substation Communication Designer is an editor for SCL files as described in `IEC 61850-6`.
 
+This package is published to npm as `@compas-oscd/open-scd`.
+
 > Try it out at [openscd.github.io](https://openscd.github.io)!
 
 Make sure your web browser has enough free memory! If needed, disable plug-ins and close unused browser tabs.

--- a/packages/plugins/README.md
+++ b/packages/plugins/README.md
@@ -1,3 +1,5 @@
 # `OpenSCD Official Plug-ins`
 
-All the offical plug-ins are listed [here](https://github.com/openscd/open-scd/blob/main/docs/plug-ins.md)
+All the official plug-ins are listed [here](https://github.com/openscd/open-scd/blob/main/docs/plug-ins.md).
+
+This package is published to npm as `@compas-oscd/plugins`.

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -88,6 +88,66 @@
           "jsonpath": "$.version"
         }
       ]
+    },
+    "packages/forms": {
+      "component": "forms",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "initial-version": "0.0.1",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "tag-separator": "@",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/forms/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
+    "packages/xml": {
+      "component": "xml",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "initial-version": "0.0.1",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "tag-separator": "@",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/xml/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
+    },
+    "packages/plugins": {
+      "component": "plugins",
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": false,
+      "bump-patch-for-minor-pre-major": false,
+      "draft": false,
+      "prerelease": false,
+      "initial-version": "0.0.1",
+      "include-component-in-tag": true,
+      "include-v-in-tag": true,
+      "tag-separator": "@",
+      "extra-files": [
+        {
+          "type": "json",
+          "path": "packages/plugins/package.json",
+          "jsonpath": "$.version"
+        }
+      ]
     }
   },
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",


### PR DESCRIPTION
Release automation improvements:

* Added release-please configuration for `packages/forms`, `packages/xml`, and `packages/plugins`, enabling automated versioning and changelog management for these packages.
* Updated `.release-please-manifest.json` to include initial versions for `forms`, `xml`, and `plugins`, and updated the versions for `openscd` and `core`.
* Modified `.github/workflows/release-please.yml` to use more precise conditional checks for publishing and asset steps, ensuring each package is published only if its release was created. 