### PR TITLE
feat(communication): validate duplicate IPs in ConnectedAP within the same SubNetwork

### DIFF
--- a/packages/openscd/src/wizard-textfield.ts
+++ b/packages/openscd/src/wizard-textfield.ts
@@ -113,6 +113,9 @@ export class WizardTextField extends LitElement {
   /** Additional values that cause validation to fail. */
   @property({ type: Array })
   reservedValues: string[] = [];
+  /** Optional custom error message for reserved values. */
+  @property({ type: String })
+  reservedValueMessage: string | undefined;
 
   // FIXME: workaround to allow disable of the whole component - need basic refactor
   private disabledSwitch = false;
@@ -160,7 +163,11 @@ export class WizardTextField extends LitElement {
       this.reservedValues &&
       this.reservedValues.some(array => array === this.value)
     ) {
-      this.textfield.setCustomValidity(get('textfield.unique'));
+      this.textfield.setCustomValidity(
+        this.reservedValueMessage ??
+          this.validationMessage ??
+          get('textfield.unique')
+      );
       return false;
     }
     this.textfield.setCustomValidity(''); //Reset. Otherwise super.checkValidity always falseM
@@ -233,7 +240,7 @@ export class WizardTextField extends LitElement {
           .readOnly=${this.readOnly}
           label=${this.label}
           helper="${ifDefined(this.helper)}"
-          validationMessage="${ifDefined(this.helper)}"
+          validationMessage="${ifDefined(this.validationMessage ?? this.helper)}"
           pattern="${ifDefined(this.pattern)}"
           minLength="${ifDefined(this.minLength)}"
           maxLength="${ifDefined(this.maxLength)}"

--- a/packages/plugins/src/wizards/connectedap.ts
+++ b/packages/plugins/src/wizards/connectedap.ts
@@ -333,15 +333,59 @@ export function createPTextField(
   element: Element,
   pType: string
 ): TemplateResult {
+  const currentValue =
+    element
+      .querySelector(`:scope > Address > P[type="${pType}"]`)
+      ?.textContent?.trim() ?? null;
+
+  if (pType !== 'IP') {
+    return oscdHtml`<wizard-textfield
+      required
+      label="${pType}"
+      pattern="${ifDefined(typePattern[pType])}"
+      ?nullable=${typeNullable[pType]}
+      .maybeValue=${currentValue}
+      maxLength="${ifDefined(typeMaxLength[pType])}"
+    ></wizard-textfield>`;
+  }
+
+  const duplicateIps = getDuplicateIpsInSubNetwork(element);
+
   return oscdHtml`<wizard-textfield
     required
     label="${pType}"
     pattern="${ifDefined(typePattern[pType])}"
     ?nullable=${typeNullable[pType]}
-    .maybeValue=${element.querySelector(`:scope > Address > P[type="${pType}"]`)
-      ?.innerHTML ?? null}
+    .maybeValue=${currentValue}
     maxLength="${ifDefined(typeMaxLength[pType])}"
+    .reservedValues=${duplicateIps}
+    .reservedValueMessage=${
+      duplicateIps.length
+        ? 'IP address is already in use in the subnetwork, a unique IP address is required'
+        : undefined
+    }
   ></wizard-textfield>`;
+}
+
+function getDuplicateIpsInSubNetwork(connectedAp: Element): string[] {
+  const subNetwork = connectedAp.closest('SubNetwork');
+  if (!subNetwork) return [];
+
+  const duplicateIps: string[] = [];
+
+  Array.from(subNetwork.querySelectorAll(':scope > ConnectedAP'))
+    .filter(otherConnectedAp => otherConnectedAp !== connectedAp)
+    .forEach(otherConnectedAp => {
+      const ip = otherConnectedAp
+        .querySelector(':scope > Address > P[type="IP"]')
+        ?.textContent?.trim();
+
+      if (!ip || duplicateIps.includes(ip)) return;
+
+      duplicateIps.push(ip);
+    });
+
+  return duplicateIps;
 }
 
 /** @returns single page  [[`Wizard`]] for creating SCL element ConnectedAP. */

--- a/packages/plugins/test/unit/wizards/connectedap.test.ts
+++ b/packages/plugins/test/unit/wizards/connectedap.test.ts
@@ -20,6 +20,31 @@ import {
 } from '@openscd/core/foundation/deprecated/editor.js';
 import { editConnectedApWizard } from '../../../src/wizards/connectedap.js';
 
+/** Create a second ConnectedAP in StationBus with a known IP to test duplicate-IP validation. */
+function addDuplicateConnectedApInStationBus(doc: XMLDocument): void {
+  const stationBus = doc.querySelector('SubNetwork[name="StationBus"]');
+  const firstConnectedAp = stationBus?.querySelector(':scope > ConnectedAP');
+  if (stationBus && firstConnectedAp) {
+    const duplicateConnectedAp = firstConnectedAp.cloneNode(true) as Element;
+    duplicateConnectedAp.setAttribute('iedName', 'IED-DUPLICATE');
+    duplicateConnectedAp.setAttribute('apName', 'P2');
+    const duplicateIp = duplicateConnectedAp.querySelector(
+      ':scope > Address > P[type="IP"]'
+    );
+    if (duplicateIp) duplicateIp.textContent = '192.168.210.112';
+    stationBus.appendChild(duplicateConnectedAp);
+  }
+}
+
+async function openConnectedApWizard(
+  element: OscdWizards,
+  doc: XMLDocument
+): Promise<void> {
+  const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
+  element.workflow = [() => wizard];
+  await element.requestUpdate();
+}
+
 describe('Wizards for SCL element ConnectedAP', () => {
   let doc: XMLDocument;
   let element: OscdWizards;
@@ -44,9 +69,7 @@ describe('Wizards for SCL element ConnectedAP', () => {
         .then(response => response.text())
         .then(str => new DOMParser().parseFromString(str, 'application/xml'));
 
-      const wizard = editConnectedApWizard(doc.querySelector('ConnectedAP')!);
-      element.workflow.push(() => wizard);
-      await element.requestUpdate();
+      await openConnectedApWizard(element, doc);
 
       inputs = Array.from(element.wizardUI.inputs);
 
@@ -164,6 +187,45 @@ describe('Wizards for SCL element ConnectedAP', () => {
           'type'
         )
       ).to.exist;
+    });
+
+    it('shows contextual error for duplicate IP in same SubNetwork', async () => {
+      addDuplicateConnectedApInStationBus(doc);
+      await openConnectedApWizard(element, doc);
+      inputs = Array.from(element.wizardUI.inputs);
+
+      input = <WizardTextField>inputs.find(input => input.label === 'IP');
+      input.value = '192.168.210.112';
+      await input.requestUpdate();
+
+      expect(input.checkValidity()).to.be.false;
+      const textField = input.shadowRoot?.querySelector('mwc-textfield') as {
+        validationMessage: string;
+      };
+      expect(textField.validationMessage).to.equal(
+        'IP address is already in use in the subnetwork, a unique IP address is required'
+      );
+    });
+
+    it('does not emit update action when duplicate IP is entered', async () => {
+      addDuplicateConnectedApInStationBus(doc);
+      await openConnectedApWizard(element, doc);
+      inputs = Array.from(element.wizardUI.inputs);
+
+      primaryAction = <HTMLElement>(
+        element.wizardUI.dialog?.querySelector(
+          'mwc-button[slot="primaryAction"]'
+        )
+      );
+
+      input = <WizardTextField>inputs.find(input => input.label === 'IP');
+      input.value = '192.168.210.112';
+      await input.requestUpdate();
+
+      primaryAction.click();
+      await element.requestUpdate();
+
+      expect(actionEvent).to.not.have.been.called;
     });
   });
 });


### PR DESCRIPTION
This PR adds IP validation to the ConnectedAP edit wizard (Communication Plugin).

# What changed
- Added duplicate-IP validation for the IP field against other ConnectedAP entries in the same SubNetwork.
- Added support in wizard-textfield for a custom reserved-value validation message.
- Wired ConnectedAP IP validation to show a clearer error message when the IP is already used.
- Added unit tests for duplicate-IP validation.

**Example SCD snippet (duplicate IP in same SubNetwork):**

```xml
<SubNetwork name="StationBus" type="8-MMS">
  <ConnectedAP iedName="IED1" apName="P1">
    <Address>
      <P type="IP">192.168.210.111</P>
      <P type="IP-SUBNET">255.255.255.0</P>
      <P type="IP-GATEWAY">192.168.210.1</P>
      ...
    </Address>
  </ConnectedAP>

  <ConnectedAP iedName="IED2" apName="P1">
    <Address>
      <P type="IP">192.168.210.111</P>
      <P type="IP-SUBNET">255.255.255.0</P>
      <P type="IP-GATEWAY">192.168.210.1</P>
      ...
    </Address>
  </ConnectedAP>
</SubNetwork>
```


<img width="569" height="393" alt="image" src="https://github.com/user-attachments/assets/167ad11e-99b6-486f-89ba-e129f00dbef6" />

# Context

This PR was first created in in [com-pas/compas-open-scd](https://github.com/com-pas/compas-open-scd/pull/455). It was already reviewed and the feedback is implemented in this PR. 

