### PR TITLE
fix: reset previous validation errors when validating

### DIFF
--- a/packages/openscd/src/addons/History.ts
+++ b/packages/openscd/src/addons/History.ts
@@ -145,6 +145,9 @@ export class OscdHistory extends LitElement {
   @state()
   history: HistoryItem[] = [];
 
+  @state()
+  validationTimes = new Map<string, Date>();
+
   get canRedo(): boolean {
     return this.editor.future.length >= 1;
   }
@@ -168,6 +171,8 @@ export class OscdHistory extends LitElement {
 
     if (!issues) this.diagnoses.set(de.detail.validatorId, [de.detail]);
     else issues?.push(de.detail);
+
+    this.validationTimes.set(de.detail.validatorId, new Date());
 
     this.latestIssue = de.detail;
     this.issueUI.close();
@@ -315,12 +320,12 @@ export class OscdHistory extends LitElement {
         graphic="icon"
         ?twoline=${!!entry.message}
       >
-        <span>
+        <span class="selectable-text">
           <!-- FIXME: replace tt with mwc-chip asap -->
           <tt>${entry.time?.toLocaleString()}</tt>
           ${entry.title}</span
         >
-        <span slot="secondary">${entry.message}</span>
+        <span class="selectable-text" slot="secondary">${entry.message}</span>
         <mwc-icon
           slot="graphic"
           style="--mdc-theme-text-icon-on-background:var(${iconColors[
@@ -356,6 +361,13 @@ export class OscdHistory extends LitElement {
     return `${hours.toString().padStart(2, '0')}:${minutes.toString().padStart(2, '0')}`
   }
 
+  private formatValidationTime(time: number): string {
+    const date = new Date(time);
+    const dateStr = date.toLocaleDateString();
+    const timeStr = date.toLocaleTimeString();
+    return `${dateStr} ${timeStr}`;
+  }
+
   private renderLog(): TemplateResult[] | TemplateResult {
     if (this.log.length > 0)
       return this.log.slice().reverse().map(this.renderLogEntry, this);
@@ -378,19 +390,30 @@ export class OscdHistory extends LitElement {
 
   protected renderIssueEntry(issue: IssueDetail): TemplateResult {
     return html` <abbr title="${issue.title + '\n' + issue.message}"
-      ><mwc-list-item ?twoline=${!!issue.message}>
-        <span> ${issue.title}</span>
-        <span slot="secondary">${issue.message}</span>
+      ><mwc-list-item noninteractive ?twoline=${!!issue.message}>
+        <span class="selectable-text"> ${issue.title}</span>
+        <span class="selectable-text" slot="secondary">${issue.message}</span>
       </mwc-list-item></abbr
     >`;
   }
 
   renderValidatorsIssues(issues: IssueDetail[]): TemplateResult[] {
     if (issues.length === 0) return [html``];
+
+    const lastValidated = this.validationTimes.get(issues[0].validatorId);
+
     return [
       html`
-        <mwc-list-item noninteractive>
-          ${getPluginName(issues[0].validatorId)}
+        <mwc-list-item noninteractive ?twoline=${!!lastValidated}>
+            <span>${getPluginName(issues[0].validatorId)}</span>
+            ${lastValidated
+              ? html`<span slot="secondary" class="validation-time"
+                  >${get('diag.lastValidated', {
+                    time: this.formatValidationTime(lastValidated.getTime()),
+                  })}</span
+                >`
+              : ''}
+          </span>
         </mwc-list-item>
       `,
       html`<li divider padded role="separator"></li>`,
@@ -460,6 +483,18 @@ export class OscdHistory extends LitElement {
   render(): TemplateResult {
     return html`<slot></slot>
       <style>
+        .selectable-text {
+          user-select: text;
+          -webkit-user-select: text;
+          cursor: text;
+        }
+  
+        .validation-time {
+          color: var(--base1);
+          font-size: 0.85em;
+          white-space: nowrap;
+        }
+        
         #log > mwc-icon-button-toggle {
           position: absolute;
           top: 8px;

--- a/packages/openscd/src/addons/Layout.ts
+++ b/packages/openscd/src/addons/Layout.ts
@@ -338,6 +338,8 @@ export class OscdLayout extends LitElement {
               return;
             }
 
+            this.dispatchEvent(newEmptyIssuesEvent(src));
+
             return (menuContentElement as unknown as Validator).validate()
           })
       ).then();

--- a/packages/openscd/src/translations/de.ts
+++ b/packages/openscd/src/translations/de.ts
@@ -181,6 +181,7 @@ export const de: Translations = {
     placeholder: 'Hier werden Validierungsfehler angezeigt.',
     missingnsd:
       'DataTypeTemplates können nicht validiert werden. Das Projekt muss die Version 2007B4 oder höher haben.',
+    lastValidated: 'Validiert um {{ time }}',
   },
   plugins: {
     heading: 'Plug-ins',

--- a/packages/openscd/src/translations/en.ts
+++ b/packages/openscd/src/translations/en.ts
@@ -158,6 +158,7 @@ export const en = {
     placeholder: 'Issues found during validation will show up here',
     missingnsd:
       'Cannot validate DataTypeTemplates. The version of the project must be higher than or equal to 2007B4',
+    lastValidated: 'Validated at {{ time }}',
   },
   plugins: {
     heading: 'Plug-ins',

--- a/packages/openscd/test/unit/Historing.test.ts
+++ b/packages/openscd/test/unit/Historing.test.ts
@@ -223,5 +223,31 @@ describe('HistoringElement', () => {
       await element.updateComplete;
       expect(element.diagnoses.size).to.equal(0);
     });
+
+    it('clears only the targeted validator on empty-issues', async () => {
+      element.dispatchEvent(
+        newIssueEvent({
+          validatorId: '/src/validators/ValidateTemplates.js',
+          title: 'template issue',
+        })
+      );
+      await element.updateComplete;
+
+      mock.dispatchEvent(
+        new CustomEvent('empty-issues', {
+          bubbles: true,
+          composed: true,
+          detail: { pluginSrc: '/src/validators/ValidateSchema.js' },
+        })
+      );
+      await element.updateComplete;
+
+      expect(
+        element.diagnoses.get('/src/validators/ValidateSchema.js')!.length
+      ).to.equal(0);
+      expect(
+        element.diagnoses.get('/src/validators/ValidateTemplates.js')!.length
+      ).to.equal(1);
+    });
   });
 });

--- a/packages/plugins/test/integration/validators/ValidateSchema.test.ts
+++ b/packages/plugins/test/integration/validators/ValidateSchema.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { useFakeTimers } from 'sinon';
 
 import '@compas-oscd/open-scd/dist/test-helper';
 import { MockOpenSCD } from '@compas-oscd/open-scd/dist/test-helper';
@@ -13,9 +14,18 @@ describe('ValidateSchema plugin', () => {
 
   let parent: MockOpenSCD;
   let element: ValidateSchema;
+  let clock: { restore: () => void };
 
   let valid2007B4: XMLDocument;
   let invalid2007B: XMLDocument;
+
+  before(() => {
+    clock = useFakeTimers(new Date(2026, 7, 7, 15, 6, 22));
+  });
+
+  after(() => {
+    clock.restore();
+  });
 
   before(async () => {
     parent = await fixture(html`

--- a/packages/plugins/test/integration/validators/ValidateTemplates.test.ts
+++ b/packages/plugins/test/integration/validators/ValidateTemplates.test.ts
@@ -1,4 +1,5 @@
 import { expect, fixture, html } from '@open-wc/testing';
+import { useFakeTimers } from 'sinon';
 
 import '@compas-oscd/open-scd/dist/test-helper';
 import { MockOpenSCD } from '@compas-oscd/open-scd/dist/test-helper';
@@ -12,8 +13,17 @@ describe('ValidateTemplates OpenSCD integration test ', () => {
 
   let parent: MockOpenSCD;
   let element: ValidateTemplates;
+  let clock: { restore: () => void };
 
   let doc: XMLDocument;
+
+  before(() => {
+    clock = useFakeTimers(new Date(2026, 7, 7, 15, 6, 22));
+  });
+
+  after(() => {
+    clock.restore();
+  });
 
   describe('with a valid DataTypeTemplates section', () => {
     beforeEach(async () => {

--- a/packages/plugins/test/integration/validators/__snapshots__/ValidateSchema.test.snap.js
+++ b/packages/plugins/test/integration/validators/__snapshots__/ValidateSchema.test.snap.js
@@ -14,8 +14,17 @@ snapshots["ValidateSchema plugin for valid SCL files zeroissues indication looks
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
+      twoline=""
     >
-      Validate Schema
+      <span>
+        Validate Schema
+      </span>
+      <span
+        class="validation-time"
+        slot="secondary"
+      >
+        Validated at 8/7/2026 3:06:22 PM
+      </span>
     </mwc-list-item>
     <li
       divider=""
@@ -27,13 +36,16 @@ snapshots["ValidateSchema plugin for valid SCL files zeroissues indication looks
 undefined">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
       >
-        <span>
+        <span class="selectable-text">
           valid2007B XML schema validation successful
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
         </span>
       </mwc-list-item>
     </abbr>
@@ -61,8 +73,17 @@ snapshots["ValidateSchema plugin for invalid SCL files pushes issues to the diag
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
+      twoline=""
     >
-      Validate Schema
+      <span>
+        Validate Schema
+      </span>
+      <span
+        class="validation-time"
+        slot="secondary"
+      >
+        Validated at 8/7/2026 3:06:22 PM
+      </span>
     </mwc-list-item>
     <li
       divider=""
@@ -74,25 +95,34 @@ snapshots["ValidateSchema plugin for invalid SCL files pushes issues to the diag
 invalid2007B:7 Substation name (Element '{http://www.iec.ch/61850/2003/SCL}Substation')">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute 'name' is required but missing.
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           invalid2007B:7 Substation name (Element '{http://www.iec.ch/61850/2003/SCL}Substation')
         </span>
       </mwc-list-item>
     </abbr>
     <abbr title="Not all fields of key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' evaluate to a node.
 invalid2007B:7 Substation key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' (Element '{http://www.iec.ch/61850/2003/SCL}Substation')">
-      <mwc-list-item twoline="">
-        <span>
+      <mwc-list-item
+        noninteractive=""
+        twoline=""
+      >
+        <span class="selectable-text">
           Not all fields of key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' evaluate to a node.
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           invalid2007B:7 Substation key identity-constraint '{http://www.iec.ch/61850/2003/SCL}SubstationKey' (Element '{http://www.iec.ch/61850/2003/SCL}Substation')
         </span>
       </mwc-list-item>

--- a/packages/plugins/test/integration/validators/__snapshots__/ValidateTemplates.test.snap.js
+++ b/packages/plugins/test/integration/validators/__snapshots__/ValidateTemplates.test.snap.js
@@ -14,8 +14,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with a valid DataTypeTemp
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
+      twoline=""
     >
-      Validate Templates
+      <span>
+        Validate Templates
+      </span>
+      <span
+        class="validation-time"
+        slot="secondary"
+      >
+        Validated at 8/7/2026 3:06:22 PM
+      </span>
     </mwc-list-item>
     <li
       divider=""
@@ -27,13 +36,16 @@ snapshots["ValidateTemplates OpenSCD integration test  with a valid DataTypeTemp
 undefined">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
       >
-        <span>
+        <span class="selectable-text">
           No errors found in the project
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
         </span>
       </mwc-list-item>
     </abbr>
@@ -61,8 +73,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
+      twoline=""
     >
-      Validate Templates
+      <span>
+        Validate Templates
+      </span>
+      <span
+        class="validation-time"
+        slot="secondary"
+      >
+        Validated at 8/7/2026 3:06:22 PM
+      </span>
     </mwc-list-item>
     <li
       divider=""
@@ -74,14 +95,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.CSWI > Pos">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           lnClass CSWI is missing mandatory child DO Pos
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.CSWI > Pos
         </span>
       </mwc-list-item>
@@ -90,14 +114,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.CILO > Beh">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           lnClass CILO is missing mandatory child DO Beh
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.CILO > Beh
         </span>
       </mwc-list-item>
@@ -106,14 +133,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.XSWI1 > SwTyp">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           lnClass XSWI is missing mandatory child DO SwTyp
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.XSWI1 > SwTyp
         </span>
       </mwc-list-item>
@@ -122,14 +152,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.invalidChild>NamPlt">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute type is required but missing in DO
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.invalidChild>NamPlt
         </span>
       </mwc-list-item>
@@ -138,14 +171,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.MissingLnClass">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute lnClass is required but missing in LNodeType
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.MissingLnClass
         </span>
       </mwc-list-item>
@@ -154,14 +190,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.LLN0.Mod>stVal">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:stVal has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.LLN0.Mod>stVal
         </span>
       </mwc-list-item>
@@ -170,14 +209,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.LLN0.Beh>stVal">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:stVal has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.LLN0.Beh>stVal
         </span>
       </mwc-list-item>
@@ -186,14 +228,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.LLN0.Health">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class ENS is missing mandatory child DA stVal
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.LLN0.Health
         </span>
       </mwc-list-item>
@@ -202,14 +247,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.SPC2">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class SPC is missing mandatory child DA SBO
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.SPC2
         </span>
       </mwc-list-item>
@@ -218,14 +266,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.SPC1">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class SPC is missing mandatory child DA SBOw
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.SPC1
         </span>
       </mwc-list-item>
@@ -234,14 +285,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.SPC8">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class SPC is missing mandatory child DA Cancel
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.SPC8
         </span>
       </mwc-list-item>
@@ -250,14 +304,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.SPC3">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class SPC is missing mandatory child DA Oper
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.SPC3
         </span>
       </mwc-list-item>
@@ -266,14 +323,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.XCBR1.Pos">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class DPC is missing mandatory child DA t
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.XCBR1.Pos
         </span>
       </mwc-list-item>
@@ -282,14 +342,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.CSWI.Pos1">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           Common Data Class DPC is missing mandatory child DA ctlModel
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.CSWI.Pos1
         </span>
       </mwc-list-item>
@@ -298,14 +361,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.XCBR1.badNamPlt">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute cdc is incorrect in the element DOType.
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.XCBR1.badNamPlt
         </span>
       </mwc-list-item>
@@ -314,14 +380,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.MissingCDC">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute cdc is required but missing in DOType
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.MissingCDC
         </span>
       </mwc-list-item>
@@ -330,14 +399,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.MissingType>SBOw">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute type is required but missing in DA
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.MissingType>SBOw
         </span>
       </mwc-list-item>
@@ -346,14 +418,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.MissingType>Oper">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute type is required but missing in DA
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.MissingType>Oper
         </span>
       </mwc-list-item>
@@ -362,14 +437,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.MissingType>Cancel">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute type is required but missing in DA
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.MissingType>Cancel
         </span>
       </mwc-list-item>
@@ -378,14 +456,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.badWYE>phsA">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           The attribute type is required but missing in SDO
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.badWYE>phsA
         </span>
       </mwc-list-item>
@@ -394,14 +475,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.LLN0.Mod.SBOw>ctlVal">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:ctlVal has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.LLN0.Mod.SBOw>ctlVal
         </span>
       </mwc-list-item>
@@ -410,14 +494,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.LLN0.Mod.Cancel>ctlVal">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:ctlVal has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.LLN0.Mod.Cancel>ctlVal
         </span>
       </mwc-list-item>
@@ -426,14 +513,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.Operfalse">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DAType Dummy.Operfalse is missing mandatory child BDA ctlNum
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.Operfalse
         </span>
       </mwc-list-item>
@@ -442,14 +532,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.SBOwfalse">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DAType Dummy.SBOwfalse is missing mandatory child BDA origin
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.SBOwfalse
         </span>
       </mwc-list-item>
@@ -458,14 +551,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.Cancelfalse">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DAType Dummy.Cancelfalse is missing mandatory child BDA ctlVal
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.Cancelfalse
         </span>
       </mwc-list-item>
@@ -474,14 +570,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.ScaledValueConfig">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DAType Dummy.ScaledValueConfig is missing mandatory child BDA scaleFactor
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.ScaledValueConfig
         </span>
       </mwc-list-item>
@@ -490,14 +589,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.unit>SIUnit">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:SIUnit has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.unit>SIUnit
         </span>
       </mwc-list-item>
@@ -506,14 +608,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with issues in the DataTy
 #Dummy.unit>multiplier">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
         twoline=""
       >
-        <span>
+        <span class="selectable-text">
           DO:multiplier has a invalid reference - type attribute cannot be connected to a template
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
           #Dummy.unit>multiplier
         </span>
       </mwc-list-item>
@@ -542,8 +647,17 @@ snapshots["ValidateTemplates OpenSCD integration test  with schema version small
       aria-disabled="false"
       noninteractive=""
       tabindex="-1"
+      twoline=""
     >
-      Validate Templates
+      <span>
+        Validate Templates
+      </span>
+      <span
+        class="validation-time"
+        slot="secondary"
+      >
+        Validated at 8/7/2026 3:06:22 PM
+      </span>
     </mwc-list-item>
     <li
       divider=""
@@ -555,13 +669,16 @@ snapshots["ValidateTemplates OpenSCD integration test  with schema version small
 ">
       <mwc-list-item
         aria-disabled="false"
-        mwc-list-item=""
+        noninteractive=""
         tabindex="-1"
       >
-        <span>
+        <span class="selectable-text">
           Cannot validate DataTypeTemplates. The version of the project must be higher than or equal to 2007B4
         </span>
-        <span slot="secondary">
+        <span
+          class="selectable-text"
+          slot="secondary"
+        >
         </span>
       </mwc-list-item>
     </abbr>


### PR DESCRIPTION
Closes com-pas/compas-open-scd#547

* Clears previous validation results when revalidating
* Displays date/time of validation for each validation type
* Make validation errors text selectable

<img width="570" height="808" alt="Screenshot 2026-08-07 at 14 58 28" src="https://github.com/user-attachments/assets/5d2468c4-f33d-408a-9b12-242ec8d44ab7" />
